### PR TITLE
char:diag:diag_dci.c include vmalloc.h

### DIFF
--- a/drivers/char/diag/diag_dci.c
+++ b/drivers/char/diag/diag_dci.c
@@ -26,6 +26,7 @@
 #include <linux/reboot.h>
 #include <asm/current.h>
 #include <soc/qcom/restart.h>
+#include <linux/vmalloc.h>
 #ifdef CONFIG_DIAG_OVER_USB
 #include <linux/usb/usbdiag.h>
 #endif


### PR DESCRIPTION
vzalloc() and vfree() are used in extract_dci_pkt_rsp(), so we have to include vmalloc.h to avoid implicit declaration.