### PR TITLE
Compatibility for gcc 10

### DIFF
--- a/scripts/dtc/Makefile
+++ b/scripts/dtc/Makefile
@@ -9,7 +9,7 @@ dtc-objs	+= dtc-lexer.lex.o dtc-parser.tab.o
 
 # Source files need to get at the userspace version of libfdt_env.h to compile
 
-HOSTCFLAGS_DTC := -I$(src) -I$(src)/libfdt
+HOSTCFLAGS_DTC := -fcommon -I$(src) -I$(src)/libfdt
 
 HOSTCFLAGS_checks.o := $(HOSTCFLAGS_DTC)
 HOSTCFLAGS_data.o := $(HOSTCFLAGS_DTC)


### PR DESCRIPTION
This sets -fcommon option (was default in gcc <= 9), because otherwise these outdated dtc scripts do not build with gcc 10